### PR TITLE
Fix numpy tostring deprecation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 cffi = "*"
-numpy = "*"
+numpy = ">=1.11"
 
 [dev-packages]
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
 cffi
-numpy
+numpy>=1.11

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     license='BSD 3-clause',
     packages=['soundcard', 'soundcard.__pyinstaller'],
     package_data={'soundcard': ['*.py.h']},
-    install_requires=['numpy', 'cffi'],
+    install_requires=['numpy>=1.11', 'cffi'],
     python_requires='>=3.5',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/soundcard/coreaudio.py
+++ b/soundcard/coreaudio.py
@@ -728,7 +728,7 @@ class _Resampler:
 
     def converter_callback(self, converter, numberpackets, bufferlist, desc, userdata):
         numframes = min(numberpackets[0], len(self.todo), self.blocksize)
-        raw_data = self.todo[:numframes].tostring()
+        raw_data = self.todo[:numframes].tobytes()
         _ffi.memmove(self.outdata, raw_data, len(raw_data))
         bufferlist[0].mBuffers[0].mDataByteSize = len(raw_data)
         bufferlist[0].mBuffers[0].mData = self.outdata

--- a/soundcard/mediafoundation.py
+++ b/soundcard/mediafoundation.py
@@ -665,7 +665,7 @@ class _Player(_AudioClient):
             if towrite == 0:
                 time.sleep(0.001)
                 continue
-            bytes = data[:towrite].ravel().tostring()
+            bytes = data[:towrite].ravel().tobytes()
             buffer = self._render_buffer(towrite)
             _ffi.memmove(buffer[0], bytes, len(bytes))
             self._render_release(towrite)

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -783,7 +783,7 @@ class _Player(_Stream):
             if nwrite == 0:
                 time.sleep(0.001)
                 continue
-            bytes = data[:nwrite].ravel().tostring()
+            bytes = data[:nwrite].ravel().tobytes()
             _pulse._pa_stream_write(self.stream, bytes, len(bytes), _ffi.NULL, 0, _pa.PA_SEEK_RELATIVE)
             data = data[nwrite:]
 


### PR DESCRIPTION
## Summary
- use `numpy.ndarray.tobytes()` for compatibility
- set minimum numpy version to 1.11

## Testing
- `pip install -e .`
- `pytest -q` *(fails: cannot load library 'libpulse.so')*

------
https://chatgpt.com/codex/tasks/task_e_6847138978fc832f95c0c73d72c80f01